### PR TITLE
[Add] タワー設置数制限機能の追加

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -14,10 +14,15 @@ class GameScene extends Phaser.Scene {
         this.totalWaves = 5;
         this.isWaveActive = false;
         
+        // タワー設置の制限
+        this.maxTowers = 5;         // 最大設置可能数
+        this.remainingTowers = 5;   // 残りの設置可能数
+        
         // UI要素
         this.lifeText = null;
         this.waveText = null;
         this.scoreText = null;
+        this.towerCountText = null; // タワー設置可能数表示
     }
 
     create() {
@@ -129,6 +134,12 @@ class GameScene extends Phaser.Scene {
             fill: '#000000'
         });
         
+        // タワー設置可能数表示
+        this.towerCountText = this.add.text(20, 110, `タワー: ${this.remainingTowers}/${this.maxTowers}`, {
+            font: '18px Arial',
+            fill: '#000000'
+        });
+        
         // タワー設置ボタン
         const towerButton = this.add.image(720, 50, 'tower').setScale(0.8);
         towerButton.setInteractive();
@@ -149,12 +160,20 @@ class GameScene extends Phaser.Scene {
         if (this.lifeText) this.lifeText.setText(`ライフ: ${this.lives}`);
         if (this.waveText) this.waveText.setText(`ウェーブ: ${this.currentWave}/${this.totalWaves}`);
         if (this.scoreText) this.scoreText.setText(`スコア: ${this.score}`);
+        if (this.towerCountText) this.towerCountText.setText(`タワー: ${this.remainingTowers}/${this.maxTowers}`);
     }
 
     /**
      * タワーを設置する
      */
     placeTower(x, y) {
+        // タワー設置数の制限チェック
+        if (this.remainingTowers <= 0) {
+            // 設置可能数を超えている場合は警告表示
+            this.showWarningMessage("タワーの設置上限に達しました");
+            return;
+        }
+        
         // 座標を適切なグリッドにスナップ
         const gridSize = 50;
         const gridX = Math.floor(x / gridSize) * gridSize + gridSize / 2;
@@ -163,6 +182,41 @@ class GameScene extends Phaser.Scene {
         // 新しいタワーを作成
         const tower = new Tower(this, gridX, gridY);
         this.towers.push(tower);
+        
+        // 残りのタワー設置可能数を減らす
+        this.remainingTowers--;
+        
+        // UI更新
+        this.updateUI();
+    }
+    
+    /**
+     * 警告メッセージを表示する
+     */
+    showWarningMessage(message) {
+        // 既存の警告メッセージがあれば削除
+        if (this.warningText) {
+            this.warningText.destroy();
+        }
+        
+        // 新しい警告メッセージを表示
+        this.warningText = this.add.text(
+            this.cameras.main.width / 2,
+            150,
+            message,
+            {
+                font: 'bold 20px Arial',
+                fill: '#ff0000'
+            }
+        ).setOrigin(0.5);
+        
+        // 数秒後に自動的に消える
+        this.time.delayedCall(2000, () => {
+            if (this.warningText) {
+                this.warningText.destroy();
+                this.warningText = null;
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## 変更内容
タワーディフェンスゲームにおいて、砲台（タワー）の設置数に制限を追加しました。

### 追加した機能
- タワー設置数の上限（最大5基）
- 残りのタワー設置可能数の表示
- 設置上限に達したときの警告メッセージ表示

### 変更・修正した機能
- GameSceneクラスにタワー設置制限のロジックを追加
- UI表示に残りのタワー設置可能数を追加

### 削除した機能
- なし

## 変更理由
無限にタワーを設置できると面白くないため、限られたリソースで戦略的な配置を促すゲームバランスの改善。

## 影響範囲
- [x] 既存の機能への影響（タワー設置機能に制限を追加）
- [ ] パフォーマンスへの影響
- [ ] セキュリティへの影響

## 動作確認
- [ ] ユニットテストの追加・更新
- [x] 動作確認の実施（ローカル環境で正常動作を確認）
- [ ] ドキュメントの更新

## スクリーンショット
なし

## 補足情報
タワーの設置上限はグローバル変数として設定しているため、難易度調整などでは簡単に変更可能です。

## チェックリスト
- [x] コーディング規約に準拠している
- [x] 適切なコメントを追加している
- [ ] 必要なテストを追加している
- [ ] ドキュメントを更新している