### PR TITLE
[Add] タワーと敵の画像・エフェクトの改善

### DIFF
--- a/src/entities/Enemy.js
+++ b/src/entities/Enemy.js
@@ -117,11 +117,8 @@ class Enemy {
         
         console.log('Enemy defeated');
         
-        // 爆発エフェクト（仮の実装）
-        const explosion = this.scene.add.circle(this.x, this.y, 20, 0xff0000, 1);
-        this.scene.time.delayedCall(200, () => {
-            explosion.destroy();
-        });
+        // 爆発エフェクト（改善版）
+        this.createExplosionEffect();
         
         // ゲームマネージャーに通知
         if (this.scene.gameManager) {
@@ -133,6 +130,59 @@ class Enemy {
         
         // スプライトの破棄
         this.destroy();
+    }
+    
+    /**
+     * 爆発エフェクトを作成
+     */
+    createExplosionEffect() {
+        // 爆発の複数のパーティクル
+        const particleColors = [0xff0000, 0xff7700, 0xffff00];
+        const particleCount = 10;
+        
+        for (let i = 0; i < particleCount; i++) {
+            // ランダムな色とサイズのパーティクル
+            const size = Phaser.Math.Between(5, 10);
+            const color = Phaser.Utils.Array.GetRandom(particleColors);
+            
+            // パーティクルの作成
+            const particle = this.scene.add.circle(this.x, this.y, size, color);
+            
+            // ランダムな方向と速度
+            const angle = Math.random() * Math.PI * 2;
+            const speed = Phaser.Math.Between(1, 3);
+            const dx = Math.cos(angle) * speed;
+            const dy = Math.sin(angle) * speed;
+            
+            // パーティクルのアニメーション
+            this.scene.tweens.add({
+                targets: particle,
+                x: this.x + dx * 20,
+                y: this.y + dy * 20,
+                alpha: 0,
+                scaleX: 0.5,
+                scaleY: 0.5,
+                duration: 500,
+                onComplete: () => {
+                    particle.destroy();
+                }
+            });
+        }
+        
+        // 爆発の中心の閃光
+        const flash = this.scene.add.circle(this.x, this.y, 15, 0xffffff);
+        
+        // 閃光のアニメーション
+        this.scene.tweens.add({
+            targets: flash,
+            alpha: 0,
+            scaleX: 2,
+            scaleY: 2,
+            duration: 300,
+            onComplete: () => {
+                flash.destroy();
+            }
+        });
     }
 
     /**

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -70,11 +70,11 @@ class BootScene extends Phaser.Scene {
      * アセットの読み込み
      */
     loadAssets() {
-        // 画像アセットの読み込み - 色付きの矩形でプレースホルダーを代用
-        this.createColorImage('tower', 50, 50, '#4a90e2');
-        this.createColorImage('enemy', 40, 40, '#e24a4a');
-        this.createColorImage('background', 800, 600, '#f0f0f0');
-        this.createColorImage('button', 100, 50, '#4a90e2');
+        // 画像アセットの読み込み
+        this.createTowerImage();  // タワー（砲台）の画像を生成
+        this.createEnemyImage();  // 敵の画像を生成
+        this.createColorImage('background', 800, 600, '#f0f0f0');  // 背景
+        this.createButtonImage(); // ボタン画像を生成
         
         // テキスト用のフォント読み込み（必要に応じて）
         
@@ -99,6 +99,112 @@ class BootScene extends Phaser.Scene {
         
         // 画像をテクスチャとして保存
         graphics.generateTexture(key, width, height);
+        graphics.destroy();
+    }
+    
+    /**
+     * タワー（砲台）の画像を生成する
+     */
+    createTowerImage() {
+        const graphics = this.add.graphics();
+        
+        // タワーの土台
+        graphics.fillStyle(0x666666, 1);
+        graphics.fillRect(10, 35, 30, 15);
+        
+        // タワーの本体
+        graphics.fillStyle(0x4a90e2, 1);
+        graphics.fillRect(15, 15, 20, 20);
+        
+        // タワーの砲身
+        graphics.fillStyle(0x333333, 1);
+        graphics.fillRect(22, 5, 6, 25);
+        
+        // タワーの砲塔
+        graphics.fillStyle(0x5a9ff2, 1);
+        graphics.beginPath();
+        graphics.arc(25, 15, 10, 0, 2 * Math.PI);
+        graphics.closePath();
+        graphics.fill();
+        
+        // ハイライト
+        graphics.fillStyle(0xffffff, 0.5);
+        graphics.beginPath();
+        graphics.arc(22, 12, 3, 0, 2 * Math.PI);
+        graphics.closePath();
+        graphics.fill();
+        
+        // 画像をテクスチャとして保存
+        graphics.generateTexture('tower', 50, 50);
+        graphics.destroy();
+    }
+    
+    /**
+     * 敵の画像を生成する
+     */
+    createEnemyImage() {
+        const graphics = this.add.graphics();
+        
+        // 敵の本体（三角形）
+        graphics.fillStyle(0xe24a4a, 1);
+        graphics.beginPath();
+        graphics.moveTo(20, 0);
+        graphics.lineTo(40, 30);
+        graphics.lineTo(0, 30);
+        graphics.closePath();
+        graphics.fill();
+        
+        // 敵の目
+        graphics.fillStyle(0xffffff, 1);
+        graphics.beginPath();
+        graphics.arc(15, 15, 4, 0, 2 * Math.PI);
+        graphics.closePath();
+        graphics.fill();
+        
+        graphics.fillStyle(0xffffff, 1);
+        graphics.beginPath();
+        graphics.arc(25, 15, 4, 0, 2 * Math.PI);
+        graphics.closePath();
+        graphics.fill();
+        
+        // 瞳
+        graphics.fillStyle(0x000000, 1);
+        graphics.beginPath();
+        graphics.arc(15, 15, 2, 0, 2 * Math.PI);
+        graphics.closePath();
+        graphics.fill();
+        
+        graphics.fillStyle(0x000000, 1);
+        graphics.beginPath();
+        graphics.arc(25, 15, 2, 0, 2 * Math.PI);
+        graphics.closePath();
+        graphics.fill();
+        
+        // 画像をテクスチャとして保存
+        graphics.generateTexture('enemy', 40, 40);
+        graphics.destroy();
+    }
+    
+    /**
+     * ボタン画像を生成する
+     */
+    createButtonImage() {
+        const graphics = this.add.graphics();
+        
+        // ボタンの背景
+        graphics.fillStyle(0x4a90e2, 1);
+        graphics.fillRect(0, 0, 100, 50);
+        
+        // ボタンの枠線
+        graphics.lineStyle(2, 0x357abd, 1);
+        graphics.strokeRect(0, 0, 100, 50);
+        
+        // ボタンのハイライト（上部）
+        graphics.fillStyle(0xffffff, 0.3);
+        graphics.fillRect(2, 2, 96, 10);
+        
+        // 画像をテクスチャとして保存
+        graphics.generateTexture('button', 100, 50);
         graphics.destroy();
     }
 }


### PR DESCRIPTION
## 変更内容

タワーディフェンスゲーム「Yasashi Tower」の視覚的な改良を実装しました。

### 1. タワー（砲台）の視覚的改良
- 土台、本体、砲身、砲塔を持つ詳細なタワー画像
- 砲塔からの発射エフェクト
- ビームエフェクトとビームに沿った発光点
- 敵への衝撃エフェクト

### 2. 敵の視覚的改良
- 目を持つ三角形のキャラクターデザイン
- カラフルなパーティクルと閃光を使用した爆発エフェクト

### 3. その他の改良
- ボタンの立体的デザイン

これらの変更により、ゲームの視覚的な魅力が向上し、プレイ体験がより楽しくなります。